### PR TITLE
feat: añadir modelo de etiquetas para recursos

### DIFF
--- a/data/companies.xml
+++ b/data/companies.xml
@@ -25,7 +25,7 @@
       <field name="website">https://portal.edu.gva.es/ceedcv</field>
       <field name="currency_id" ref="base.EUR"/>
       <field name="color">1</field>
-      <field name="parent_id" ref="base.main_company"/>
+      <!-- <field name="parent_id" ref="base.main_company"/> -->
     </record>
 
     <!-- Bachillerato  -->
@@ -39,7 +39,7 @@
       <field name="website">https://portal.edu.gva.es/ceedcv</field>
       <field name="currency_id" ref="base.EUR"/>
       <field name="color">10</field>
-      <field name="parent_id" ref="base.main_company"/>
+      <!-- <field name="parent_id" ref="base.main_company"/> -->
     </record>
 
     <!-- FPA -->
@@ -53,7 +53,7 @@
       <field name="website">https://portal.edu.gva.es/ceedcv</field>
       <field name="currency_id" ref="base.EUR"/>
       <field name="color">2</field>
-      <field name="parent_id" ref="base.main_company"/>
+      <!-- <field name="parent_id" ref="base.main_company"/> -->
     </record>
   </data>
 

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -4,5 +4,6 @@ from . import res
 from . import center
 from . import course
 from . import ir
+from . import tags
 
 from . import cron_register

--- a/models/center/place.py
+++ b/models/center/place.py
@@ -36,6 +36,11 @@ class Place(models.Model):
     string=_("Horarios de reserva"),
   )
 
+  tag_ids = fields.Many2many(
+    comodel_name='maya_core.tag',
+    string='Etiquetas'
+  )
+
   @api.constrains("image", "image_360", "floor_plan_image")
   def _check_image_size(self):
     max_size = 10 * 1024 * 1024

--- a/models/tags/__init__.py
+++ b/models/tags/__init__.py
@@ -1,0 +1,1 @@
+from . import tag

--- a/models/tags/tag.py
+++ b/models/tags/tag.py
@@ -1,0 +1,8 @@
+from odoo import models, fields
+
+class MayaCoreTag(models.Model):
+    _name = 'maya_core.tag'
+    _description = 'Etiquetas Generales'
+
+    name = fields.Char(string='Nombre de la etiqueta', required=True)
+    color = fields.Integer(string='Color')

--- a/models/tags/tag.py
+++ b/models/tags/tag.py
@@ -1,8 +1,16 @@
-from odoo import models, fields
+from odoo import models, fields, _
 
 class MayaCoreTag(models.Model):
     _name = 'maya_core.tag'
     _description = 'Etiquetas Generales'
 
-    name = fields.Char(string='Nombre de la etiqueta', required=True)
+    name = fields.Char(string=_('Nombre de la Etiqueta'), required=True)
     color = fields.Integer(string='Color')
+
+    code = fields.Char(
+        string='Código interno', 
+        help='Identificador único para lógica de negocio. No modificar.'
+    )
+    _sql_constraints = [
+        ('code_unique', 'unique(code)', '¡El código interno de la etiqueta debe ser único!')
+    ]

--- a/security/core_access.xml
+++ b/security/core_access.xml
@@ -114,6 +114,17 @@
       <field name="perm_unlink">1</field>
     </record>
 
+    <!-- TAGS -->
+    <record id="access_maya_core_tag_user" model="ir.model.access">
+      <field name="name">Acceso a etiquetas generales (Usuarios)</field>
+      <field name="model_id" ref="model_maya_core_tag"/>
+      <field name="group_id" ref="base.group_user"/>
+      <field name="perm_read">1</field>
+      <field name="perm_create">1</field>
+      <field name="perm_write">1</field>
+      <field name="perm_unlink">1</field>
+    </record>
+
     <!-- SCHOOL YEAR -->
     <record id="maya_core.school_year_user_access" model="ir.model.access">
       <field name="name">Acceso usuario general a los años escolares</field>

--- a/views/views.xml
+++ b/views/views.xml
@@ -524,6 +524,40 @@
       </field>
     </record>  
 
+    <!-- Views de Tags -->
+    <record id="view_maya_core_tag_form" model="ir.ui.view">
+        <field name="name">maya_core.tag.form</field>
+        <field name="model">maya_core.tag</field>
+        <field name="arch" type="xml">
+            <form string="Etiqueta">
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="name" placeholder="ej. Equipamiento"/>
+                            <field name="code" placeholder="ej. EQUIP"/>
+                        </group>
+                        <group>
+                            <!-- El widget color_picker muestra la paleta nativa de Odoo -->
+                            <field name="color" widget="color_picker"/>
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_maya_core_tag_list" model="ir.ui.view">
+        <field name="name">maya_core.tag.list</field>
+        <field name="model">maya_core.tag</field>
+        <field name="arch" type="xml">
+            <list string="Etiquetas" editable="bottom">
+                <field name="name"/>
+                <field name="code"/>
+                <field name="color" widget="color_picker"/>
+            </list>
+        </field>
+    </record>
+
 
     <!-- actions opening views on models -->
     <record model="ir.actions.act_window" id="maya_core.action_employee">
@@ -575,6 +609,12 @@
       <field name="view_mode">list,form</field>
     </record>
 
+    <record model="ir.actions.act_window" id="maya_core.action_tag">
+      <field name="name">Etiquetas</field>
+      <field name="res_model">maya_core.tag</field>
+      <field name="view_mode">list,form</field>
+    </record>
+
 
     <!-- Top menu item -->
     <menuitem name="Maya | Core" id="maya_core.menu_root" sequence="1"/>
@@ -599,6 +639,8 @@
               action="maya_core.action_team" sequence="3"/>
     <menuitem name="Horario de sesiones" id="maya_core.school_session_schedule" parent="maya_core.organization_school"
               action="maya_core.action_session_schedule" sequence="4"/>
+    <menuitem name="Etiquetas" id="maya_core.school_tag" parent="maya_core.organization_school"
+              action="maya_core.action_tag" sequence="5"/>
 
     <!-- menú enseñanza -->
     <menuitem name="Estudios" id="maya_core.school_study" parent="maya_core.teaching_school"

--- a/views/views.xml
+++ b/views/views.xml
@@ -218,6 +218,7 @@
                 <group col="2" >
                     <field name="location_id" options="{'no_create': True}" class="w-100"/>
                     <field name="description" placeholder="Descripción detallada del espacio..." class="w-100"/>
+                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                 </group>
               </div>
             </div>


### PR DESCRIPTION
Se ha creado un modelo nuevo de tags con los campos de 'name' (que es el que se muestra por defecto al usuario), 'color' (color de estas mismas pills) y 'code' (que se usará internamente para la búsqueda inteligente). Solo se ha añadido el campo many2many al modelo de place.py.

Se han diseñado también las vistas de formulario y list del modelo de tag, además de un subapartado de Etiquetas dentro de Organización con la vista List, desde la cual se pueden editar directamente las etiquetas creadas.